### PR TITLE
Add `ligatures` flag for Fantasque Sans Mono

### DIFF
--- a/src/data/fonts.ts
+++ b/src/data/fonts.ts
@@ -134,6 +134,14 @@ const rawFonts: Font[] = [
     srcLink: '/fonts/hasklig/font.css',
   },
   {
+    displayName: 'Fantasque Sans Mono',
+    familyName: 'Fantasque Sans Mono',
+    sort: 2,
+    ligatures: true,
+    webPage: 'https://github.com/belluzj/fantasque-sans',
+    srcLink: '/fonts/fantasque-sans-mono/font.css',
+  },
+  {
     displayName: 'Hack',
     familyName: 'Hack',
     sort: 3,
@@ -153,13 +161,6 @@ const rawFonts: Font[] = [
     sort: 3,
     webPage: 'https://fontesk.com/conta-typeface/',
     srcLink: '/fonts/conta/font.css',
-  },
-  {
-    displayName: 'Fantasque Sans Mono',
-    familyName: 'Fantasque Sans Mono',
-    sort: 3,
-    webPage: 'https://github.com/belluzj/fantasque-sans',
-    srcLink: '/fonts/fantasque-sans-mono/font.css',
   },
   ...googleFonts.map((font) => {
     const { name, ligatures } = font;


### PR DESCRIPTION
I missed the `ligatures` flag that should be added to the FSM font. This PR fixes that issue. I also moved the entry up, so it will be displayed along with other fonts with ligatures.