### PR TITLE
Mark Input font as a font without ligatures

### DIFF
--- a/src/data/fonts.ts
+++ b/src/data/fonts.ts
@@ -57,7 +57,7 @@ const rawFonts: Font[] = [
     displayName: 'Input Mono',
     familyName: 'Input Mono',
     sort: 3,
-    ligatures: true,
+    ligatures: false,
     webPage: 'https://input.fontbureau.com/',
     srcLink: '/fonts/input-mono/font.css',
   },


### PR DESCRIPTION
:wave: I noticed that Input font marked as a font with ligatures. However the `Input` font [does not have them](https://input.fontbureau.com/info/). So this pull request addresses that problem and removes the mark `ligatures` for this font.
 
## Before
![image](https://user-images.githubusercontent.com/1894248/99968143-ce5f3100-2da9-11eb-9324-e1ae4137cb23.png)

## After
![image](https://user-images.githubusercontent.com/1894248/99968405-24cc6f80-2daa-11eb-92f5-8ea5e95aa402.png)

Thanks!